### PR TITLE
CREATE_TRIGGER support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ console.log(statements);
 1. `input (string)`: the whole SQL script text to be processed
 1. `options (object)`: allow to set different configurations
   1. `strict (bool)`: allow disable strict mode which will ignore unknown types *(default=true)*
+  2. `dialect (string)`: Specify your database dialect, currently behavior only differs for `sqlite`. *(default=generic)*
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This way you have sure is a valid query before trying to identify the types.
 * TRUNCATE
 * CREATE_TABLE
 * CREATE_DATABASE
+* CREATE_TRIGGER
 * DROP_TABLE
 * DROP_DATABASE
 * UNKNOWN (only available if strict mode is disabled)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ console.log(statements);
 1. `input (string)`: the whole SQL script text to be processed
 1. `options (object)`: allow to set different configurations
   1. `strict (bool)`: allow disable strict mode which will ignore unknown types *(default=true)*
-  2. `dialect (string)`: Specify your database dialect, currently behavior only differs for `sqlite`. *(default=generic)*
+  2. `dialect (string)`: Specify your database dialect, values: `generic`, `mysql`, `psql`, `sqlite` and `mssql`. *(default=generic)*
 
 ## Contributing
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,16 @@
 import { parse } from './parser';
 
-
+const allowedDialects = ['mssql', 'sqlite', 'mysql', 'psql', 'generic'];
 /**
  * Identifier
  */
 export function identify (query, options = {}) {
   const isStrict = typeof options.strict === 'undefined' ? true : options.strict;
   const dialect = typeof options.dialect === 'undefined' ? 'generic' : options.dialect;
+
+  if (!allowedDialects.includes(dialect)) {
+    throw new Error(`Unknown dialect. Allowed values: ${allowedDialects.join(',')}`);
+  }
 
   const result = parse(query, isStrict, dialect);
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,9 @@ import { parse } from './parser';
  */
 export function identify (query, options = {}) {
   const isStrict = typeof options.strict === 'undefined' ? true : options.strict;
+  const dialect = typeof options.dialect === 'undefined' ? 'generic' : options.dialect;
 
-  const result = parse(query, isStrict);
+  const result = parse(query, isStrict, dialect);
 
   return result.body.map(statement => ({
     start: statement.start,

--- a/src/parser.js
+++ b/src/parser.js
@@ -171,7 +171,6 @@ function createInsertStatementParser ({ isStrict }) {
   return stateMachineStatementParser(statement, steps, { isStrict });
 }
 
-
 function createUpdateStatementParser ({ isStrict }) {
   const statement = {};
 
@@ -372,7 +371,6 @@ function stateMachineStatementParser (statement, steps, { isStrict, dialect = 'g
       if (statement.endStatement) {
         throw new Error('This statement has already got to the end.');
       }
-
 
       if (token.type === 'semicolon') {
         // SQLite and MSSQL require semi-colons inside the trigger. They signify the end of the trigger creation

--- a/src/parser.js
+++ b/src/parser.js
@@ -57,7 +57,7 @@ export function parse (input, isStrict = true, dialect = 'generic') {
         continue;
       }
 
-      statementParser = createStatementParserByToken(isStrict, dialect, token);
+      statementParser = createStatementParserByToken(token, { isStrict, dialect });
     }
 
     statementParser.addToken(token);
@@ -106,29 +106,29 @@ function initState ({ input, prevState }) {
 }
 
 
-function createStatementParserByToken (isStrict, dialect, token) {
+function createStatementParserByToken (token, options) {
   if (token.type === 'keyword') {
     switch (token.value.toUpperCase()) {
-      case 'SELECT': return createSelectStatementParser(isStrict);
-      case 'CREATE': return createCreateStatementParser(isStrict, dialect);
-      case 'DROP': return createDropStatementParser(isStrict);
-      case 'INSERT': return createInsertStatementParser(isStrict);
-      case 'UPDATE': return createUpdateStatementParser(isStrict);
-      case 'DELETE': return createDeleteStatementParser(isStrict);
-      case 'TRUNCATE': return createTruncateStatementParser(isStrict);
+      case 'SELECT': return createSelectStatementParser(options);
+      case 'CREATE': return createCreateStatementParser(options);
+      case 'DROP': return createDropStatementParser(options);
+      case 'INSERT': return createInsertStatementParser(options);
+      case 'UPDATE': return createUpdateStatementParser(options);
+      case 'DELETE': return createDeleteStatementParser(options);
+      case 'TRUNCATE': return createTruncateStatementParser(options);
       default: break;
     }
   }
 
-  if (!isStrict && token.type === 'unknown') {
-    return createUnknownStatementParser(isStrict);
+  if (!options.isStrict && token.type === 'unknown') {
+    return createUnknownStatementParser(options.isStrict);
   }
 
   throw new Error(`Invalid statement parser "${token.value}"`);
 }
 
 
-function createSelectStatementParser (isStrict) {
+function createSelectStatementParser ({ isStrict }) {
   const statement = {};
 
   const steps = [
@@ -148,11 +148,11 @@ function createSelectStatementParser (isStrict) {
     },
   ];
 
-  return stateMachineStatementParser(isStrict, statement, steps);
+  return stateMachineStatementParser(statement, steps, { isStrict });
 }
 
 
-function createInsertStatementParser (isStrict) {
+function createInsertStatementParser ({ isStrict }) {
   const statement = {};
 
   const steps = [
@@ -172,11 +172,11 @@ function createInsertStatementParser (isStrict) {
     },
   ];
 
-  return stateMachineStatementParser(isStrict, statement, steps);
+  return stateMachineStatementParser(statement, steps, { isStrict });
 }
 
 
-function createUpdateStatementParser (isStrict) {
+function createUpdateStatementParser ({ isStrict }) {
   const statement = {};
 
   const steps = [
@@ -196,11 +196,11 @@ function createUpdateStatementParser (isStrict) {
     },
   ];
 
-  return stateMachineStatementParser(isStrict, statement, steps);
+  return stateMachineStatementParser(statement, steps, { isStrict });
 }
 
 
-function createDeleteStatementParser (isStrict) {
+function createDeleteStatementParser ({ isStrict }) {
   const statement = {};
 
   const steps = [
@@ -220,11 +220,11 @@ function createDeleteStatementParser (isStrict) {
     },
   ];
 
-  return stateMachineStatementParser(isStrict, statement, steps);
+  return stateMachineStatementParser(statement, steps, { isStrict });
 }
 
 
-function createCreateStatementParser (isStrict, dialect) {
+function createCreateStatementParser ({ isStrict, dialect }) {
   const statement = {};
 
   const steps = [
@@ -259,11 +259,11 @@ function createCreateStatementParser (isStrict, dialect) {
     },
   ];
 
-  return stateMachineStatementParser(isStrict, statement, steps, dialect);
+  return stateMachineStatementParser(statement, steps, { isStrict, dialect });
 }
 
 
-function createDropStatementParser (isStrict) {
+function createDropStatementParser ({ isStrict }) {
   const statement = {};
 
   const steps = [
@@ -297,11 +297,11 @@ function createDropStatementParser (isStrict) {
     },
   ];
 
-  return stateMachineStatementParser(isStrict, statement, steps);
+  return stateMachineStatementParser(statement, steps, { isStrict });
 }
 
 
-function createTruncateStatementParser (isStrict) {
+function createTruncateStatementParser ({ isStrict }) {
   const statement = {};
 
   const steps = [
@@ -320,11 +320,11 @@ function createTruncateStatementParser (isStrict) {
     },
   ];
 
-  return stateMachineStatementParser(isStrict, statement, steps);
+  return stateMachineStatementParser(statement, steps, { isStrict });
 }
 
 
-function createUnknownStatementParser (isStrict) {
+function createUnknownStatementParser ({ isStrict }) {
   const statement = {};
 
   const steps = [
@@ -338,11 +338,11 @@ function createUnknownStatementParser (isStrict) {
     },
   ];
 
-  return stateMachineStatementParser(isStrict, statement, steps);
+  return stateMachineStatementParser(statement, steps, { isStrict });
 }
 
 
-function stateMachineStatementParser (isStrict, statement, steps, dialect) {
+function stateMachineStatementParser (statement, steps, { isStrict, dialect = 'generic' }) {
   let currentStepIndex = 0;
   let prevToken;
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -148,7 +148,6 @@ function createSelectStatementParser ({ isStrict }) {
   return stateMachineStatementParser(statement, steps, { isStrict });
 }
 
-
 function createInsertStatementParser ({ isStrict }) {
   const statement = {};
 
@@ -196,7 +195,6 @@ function createUpdateStatementParser ({ isStrict }) {
   return stateMachineStatementParser(statement, steps, { isStrict });
 }
 
-
 function createDeleteStatementParser ({ isStrict }) {
   const statement = {};
 
@@ -219,7 +217,6 @@ function createDeleteStatementParser ({ isStrict }) {
 
   return stateMachineStatementParser(statement, steps, { isStrict });
 }
-
 
 function createCreateStatementParser ({ isStrict, dialect }) {
   const statement = {};
@@ -259,7 +256,6 @@ function createCreateStatementParser ({ isStrict, dialect }) {
   return stateMachineStatementParser(statement, steps, { isStrict, dialect });
 }
 
-
 function createDropStatementParser ({ isStrict }) {
   const statement = {};
 
@@ -297,7 +293,6 @@ function createDropStatementParser ({ isStrict }) {
   return stateMachineStatementParser(statement, steps, { isStrict });
 }
 
-
 function createTruncateStatementParser ({ isStrict }) {
   const statement = {};
 
@@ -320,7 +315,6 @@ function createTruncateStatementParser ({ isStrict }) {
   return stateMachineStatementParser(statement, steps, { isStrict });
 }
 
-
 function createUnknownStatementParser ({ isStrict }) {
   const statement = {};
 
@@ -337,7 +331,6 @@ function createUnknownStatementParser ({ isStrict }) {
 
   return stateMachineStatementParser(statement, steps, { isStrict });
 }
-
 
 function stateMachineStatementParser (statement, steps, { isStrict, dialect = 'generic' }) {
   let currentStepIndex = 0;

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -11,6 +11,7 @@ const KEYWORDS = [
   'CREATE',
   'DROP',
   'TABLE',
+  'TRIGGER',
   'DATABASE',
   'TRUNCATE',
 ];

--- a/test/identifier/single-statement.spec.js
+++ b/test/identifier/single-statement.spec.js
@@ -36,13 +36,27 @@ describe('identifier', function () {
       expect(actual).to.eql(expected);
     });
 
-    it('should identify "CREATE TRIGGER" statement', function () {
+    it('should identify sqlite "CREATE TRIGGER" statement', function () {
       const actual = identify('CREATE TRIGGER sqlmods AFTER UPDATE ON bar FOR EACH ROW WHEN old.yay IS NULL BEGIN UPDATE bar SET yay = 1 WHERE rowid = NEW.rowid; END;', { dialect: 'sqlite' });
       const expected = [
         {
           start: 0,
           end: 134,
           text: 'CREATE TRIGGER sqlmods AFTER UPDATE ON bar FOR EACH ROW WHEN old.yay IS NULL BEGIN UPDATE bar SET yay = 1 WHERE rowid = NEW.rowid; END;',
+          type: 'CREATE_TRIGGER',
+          executionType: 'MODIFICATION',
+        },
+      ];
+      expect(actual).to.eql(expected);
+    });
+
+    it('should identify postgres "CREATE TRIGGER" statement', function () {
+      const actual = identify('CREATE TRIGGER view_insert INSTEAD OF INSERT ON my_view FOR EACH ROW EXECUTE PROCEDURE view_insert_row();');
+      const expected = [
+        {
+          start: 0,
+          end: 104,
+          text: 'CREATE TRIGGER view_insert INSTEAD OF INSERT ON my_view FOR EACH ROW EXECUTE PROCEDURE view_insert_row();',
           type: 'CREATE_TRIGGER',
           executionType: 'MODIFICATION',
         },

--- a/test/identifier/single-statement.spec.js
+++ b/test/identifier/single-statement.spec.js
@@ -36,6 +36,20 @@ describe('identifier', function () {
       expect(actual).to.eql(expected);
     });
 
+    it('should identify "CREATE TRIGGER" statement', function () {
+      const actual = identify('CREATE TRIGGER sqlmods AFTER UPDATE ON bar FOR EACH ROW WHEN old.yay IS NULL BEGIN UPDATE bar SET yay = 1 WHERE rowid = NEW.rowid; END;');
+      const expected = [
+        {
+          start: 0,
+          end: 134,
+          text: 'CREATE TRIGGER sqlmods AFTER UPDATE ON bar FOR EACH ROW WHEN old.yay IS NULL BEGIN UPDATE bar SET yay = 1 WHERE rowid = NEW.rowid; END;',
+          type: 'CREATE_TRIGGER',
+          executionType: 'MODIFICATION',
+        },
+      ];
+      expect(actual).to.eql(expected);
+    });
+
     it('should identify "CREATE DATABASE" statement', function () {
       const actual = identify('CREATE DATABASE Profile;');
       const expected = [

--- a/test/identifier/single-statement.spec.js
+++ b/test/identifier/single-statement.spec.js
@@ -37,7 +37,7 @@ describe('identifier', function () {
     });
 
     it('should identify "CREATE TRIGGER" statement', function () {
-      const actual = identify('CREATE TRIGGER sqlmods AFTER UPDATE ON bar FOR EACH ROW WHEN old.yay IS NULL BEGIN UPDATE bar SET yay = 1 WHERE rowid = NEW.rowid; END;');
+      const actual = identify('CREATE TRIGGER sqlmods AFTER UPDATE ON bar FOR EACH ROW WHEN old.yay IS NULL BEGIN UPDATE bar SET yay = 1 WHERE rowid = NEW.rowid; END;', { dialect: 'sqlite' });
       const expected = [
         {
           start: 0,


### PR DESCRIPTION
- Ignore semi-colons until after `END`
- I have no idea if this is the best way to do it, but it works

Questions:
- I've added a `dialect` option to support the weird SQLITE CREATE TRIGGER syntax. That cool?


Fixes #8 

@maxcnunes if you have some time I would appreciate your input.