### PR TITLE
upgrade babel to v7

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,5 @@
 {
-  "presets": ["es2015", "stage-0"]
+  "presets": [
+    "@babel/preset-env"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {
-    "test": "npm run lint && mocha --compilers js:babel-core/register --reporter spec --recursive ./test",
+    "test": "npm run lint && mocha --compilers js:@babel/register --reporter spec --recursive ./test",
     "test:watch": "npm run test -- --watch --watch-extensions .spec.js --bail ./test",
     "lint": "eslint src test",
     "build": "babel src --out-dir lib",
@@ -13,10 +13,10 @@
     "prepublish": "npm run build"
   },
   "devDependencies": {
-    "babel-cli": "^6.8.0",
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
     "babel-eslint": "^10.1.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.5.0",
     "eslint": "^7.16.0",
     "eslint-config-airbnb-base": "^14.2.1",


### PR DESCRIPTION
Closes #5 

This upgrades things to use the newest version of babel. We no longer need the `stage-0` preset as whatever it was being used for 5 years ago by @maxcnunes has made its way into the ECMAScript language formally that the feature is built into babel at this point.

This has a soft requirement on #12 to be merged first so that the `npm test` line works correctly due to the change of `--compilers` to `--require` for mocha.