### PR TITLE
add typing to package

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,37 @@
+export type Dialect = 'generic' | 'mysql' | 'psql' | 'sqlite' | 'mssql';
+
+export type StatementType =
+  'SELECT'
+  | 'INSERT'
+  | 'UPDATE'
+  | 'DELETE'
+  | 'CREATE_TABLE'
+  | 'CREATE_DATABASE'
+  | 'CREATE_TRIGGER'
+  | 'DROP_TABLE'
+  | 'DROP_DATABASE'
+  | 'TRUNCATE'
+  | 'UNKNOWN';
+
+export type ExecutionType = 'LISTING' | 'MODIFICATION' | 'INFORMATION' | 'UNKNOWN';
+
+export interface Options {
+  /**
+   * Disables strict mode which will ignore unknown types (defaults to true).
+   */
+  strict?: boolean;
+  /**
+   * Set dialect for database specific parsing
+   */
+  dialect?: Dialect;
+}
+
+export interface Result {
+  start: number;
+  end: number;
+  text: string;
+  type: StatementType;
+  executionType: ExecutionType;
+}
+
+export function identify(query: string, options?: Options): Result[];

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A SQL query identifier",
   "license": "MIT",
   "main": "lib/index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "npm run lint && mocha --require @babel/register --reporter spec --recursive ./test",
     "test:watch": "npm run test -- --watch --watch-extensions .spec.js --bail ./test",


### PR DESCRIPTION
This ties in the separate typing for the package available in `@types/sql-query-identifier` into this repository making it easier to keep it up-to-date with new versions until time is available to complete #3.