### PR TITLE
Add identification support for CREATE_FUNCTION

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This way you have sure is a valid query before trying to identify the types.
 * CREATE_TABLE
 * CREATE_DATABASE
 * CREATE_TRIGGER
+* CREATE_FUNCTION
 * DROP_TABLE
 * DROP_DATABASE
 * UNKNOWN (only available if strict mode is disabled)

--- a/src/parser.js
+++ b/src/parser.js
@@ -397,7 +397,9 @@ function stateMachineStatementParser (statement, steps, { isStrict, dialect = 'g
         return;
       }
 
-      if (dialect === 'mysql' && token.value === 'DEFINER') {
+      // MySQL allows for setting a definer for a function which specifies who the function is executed as.
+      // This clause is optional, and is defined between the "CREATE" and "FUNCTION" keywords for the statement.
+      if (dialect === 'mysql' && token.value.toUpperCase() === 'DEFINER') {
         statement.definer = 0;
         prevToken = token;
         return;

--- a/src/parser.js
+++ b/src/parser.js
@@ -23,6 +23,7 @@ const EXECUTION_TYPES = {
 };
 
 const dialectsWithEnds = ['sqlite', 'mssql'];
+const statementsWithEnds = ['CREATE_TRIGGER', 'CREATE_FUNCTION'];
 
 /**
  * Parser
@@ -377,7 +378,7 @@ function stateMachineStatementParser (statement, steps, { isStrict, dialect = 'g
       if (token.type === 'semicolon') {
         // SQLite and MSSQL require semi-colons inside the trigger. They signify the end of the trigger creation
         // with `END;`. This allows detection of that.
-        if (dialectsWithEnds.includes(dialect) && (['CREATE_TRIGGER', 'CREATE_FUNCTION'].includes(statement.type) && !statement.canEnd)) {
+        if (dialectsWithEnds.includes(dialect) && (statementsWithEnds.includes(statement.type) && !statement.canEnd)) {
           // do nothing
         } else {
           statement.endStatement = ';';
@@ -386,7 +387,7 @@ function stateMachineStatementParser (statement, steps, { isStrict, dialect = 'g
       }
 
       // SQLite and MSSQL triggers use `END;` to signify the end of the statement. The statement can include other semicolons.
-      if (dialectsWithEnds.includes(dialect) && token.value === 'END' && ['CREATE_TRIGGER', 'CREATE_FUNCTION'].includes(statement.type)) {
+      if (dialectsWithEnds.includes(dialect) && token.value === 'END' && statementsWithEnds.includes(statement.type)) {
         statement.canEnd = true;
         return;
       }

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -12,6 +12,7 @@ const KEYWORDS = [
   'DROP',
   'TABLE',
   'TRIGGER',
+  'FUNCTION',
   'DATABASE',
   'TRUNCATE',
 ];


### PR DESCRIPTION
closes #15

Adds support for identifying queries that are creating functions. This includes support for the definer clause when parsing a mysql query that comes between the `CREATE` and `FUNCTION`.