### PR TITLE
fix tokenizer to include underscores as part of scanned words

### DIFF
--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -258,5 +258,6 @@ function isCommentBlock (ch, state) {
 
 function isLetter (ch) {
   return (ch >= 'a' && ch <= 'z')
-      || (ch >= 'A' && ch <= 'Z');
+      || (ch >= 'A' && ch <= 'Z')
+      || ch === '_';
 }

--- a/test/tokenizer/index.spec.js
+++ b/test/tokenizer/index.spec.js
@@ -175,4 +175,15 @@ describe('scan', function () {
     };
     expect(actual).to.eql(expected);
   });
+
+  it('scans string with underscore as one token', function () {
+    const actual = scanToken(initState('end_date'));
+    const expected = {
+      type: 'unknown',
+      value: 'end_date',
+      start: 0,
+      end: 7,
+    };
+    expect(actual).to.eql(expected);
+  });
 });


### PR DESCRIPTION
Tying this work into its own PR, but this is a blocker on #20 (and probably also leaves us open to subtle bugs in the other complex statement types).

The current tokenizer scans the word `end_date` as three different tokens: `['end', '_', 'date']`. This leads to a problem where then we are using `end` on its own to indicate the end of a function/trigger block. This PR fixes the tokenizer so that underscores will not signify a break in a string, and the whole thing will be read as one token (e.g. `end_date`). I cannot come up with an instance where we would not want this new behavior.

For reference on looking at this code, the `isLetter` method is only used for scanning and tokenizing words in the `scanWord` function. It is not used elsewhere, so it's a fairly minor impact change on the overall codebase.