### PR TITLE
add support for dollar quotes to tokenizer

### DIFF
--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -259,7 +259,7 @@ function isString (ch) {
 }
 
 function isDollarQuotedString (state) {
-  return state.input.slice(state.start).match(/^\$[a-zA-Z0-9_]*\$/);
+  return state.input.slice(state.start).match(/^\$[\w]*\$/);
 }
 
 function isCommentInline (ch, state) {

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -36,8 +36,12 @@ export function scanToken (state) {
     return scanCommentBlock(state);
   }
 
-  if (isString(ch, state)) {
+  if (isString(ch)) {
     return scanString(state);
+  }
+
+  if (isDollarQuotedString(state)) {
+    return scanDollarQuotedString(state);
   }
 
   if (isLetter(ch)) {
@@ -111,6 +115,36 @@ function scanCommentInline (state) {
   const value = state.input.slice(state.start, state.position + 1);
   return {
     type: 'comment-inline',
+    value,
+    start: state.start,
+    end: state.start + value.length - 1,
+  };
+}
+
+function scanDollarQuotedString (state) {
+  const label = state.input.slice(state.start).match(/^(\$[a-zA-Z0-9_]*\$)/)[1];
+  for (let i = 0; i < (label.length - 1); i++) {
+    read(state);
+  }
+
+  let nextChar;
+  while (state.input.slice(state.position, state.position + label.length) !== label && nextChar !== null) {
+    do {
+      nextChar = read(state);
+    } while (nextChar !== '$' && nextChar !== null);
+
+    if (nextChar !== '$' && nextChar !== null) {
+      unread(state);
+    }
+  }
+
+  for (let i = 0; i < (label.length - 1); i++) {
+    read(state);
+  }
+
+  const value = state.input.slice(state.start, state.position + 1);
+  return {
+    type: 'string',
     value,
     start: state.start,
     end: state.start + value.length - 1,
@@ -221,7 +255,11 @@ function isWhitespace (ch) {
 }
 
 function isString (ch) {
-  return ch === '\'';
+  return ch === "'";
+}
+
+function isDollarQuotedString (state) {
+  return state.input.slice(state.start).match(/^\$[a-zA-Z0-9_]*\$/);
 }
 
 function isCommentInline (ch, state) {

--- a/test/tokenizer/index.spec.js
+++ b/test/tokenizer/index.spec.js
@@ -186,4 +186,26 @@ describe('scan', function () {
     };
     expect(actual).to.eql(expected);
   });
+
+  it('scans dollar quoted string', function () {
+    const actual = scanToken(initState('$$test$$'));
+    const expected = {
+      type: 'string',
+      value: '$$test$$',
+      start: 0,
+      end: 7,
+    };
+    expect(actual).to.eql(expected);
+  });
+
+  it('scans dollar quoted string with label', function () {
+    const actual = scanToken(initState('$aaa$test$aaa$'));
+    const expected = {
+      type: 'string',
+      value: '$aaa$test$aaa$',
+      start: 0,
+      end: 13,
+    };
+    expect(actual).to.eql(expected);
+  });
 });


### PR DESCRIPTION
Postgres functions that are complex are just quoted constants. The most common way of writing out these constants is using [dollar quotes](https://www.postgresqltutorial.com/dollar-quoted-string-constants/) which make the body look like regular SQL, even though it's still just a string. However, there is nothing stopping someone from using these quote method anywhere in the syntax (even though it does not really happen much in practice). We know that we're dealing with a dollar quoted string (versus other possible usages of `$`) in that the token starts with a `$`, has an optional number of letters, numbers, or underscores, and then ends with a `$`. As such, `$$` and `$foo$` are both valid labels. To end a dollar quote block, you must come across the same string as started it.

This PR adds support for these quoted strings to the tokenizer so that they're parsed as strings, instead of passing through each individual token, allowing for an easier time parsing the statements that contain these (like functions).

The `$` can appear at the beginning of parameters for a postgres function and also before a term in sql server (e.g. `$4`) to cast that to the money field, but the only case of having `$[a-zA-Z0-9_]*$` is in the case of these quoted strings.

This is a blocker for #20 to be completed.