### PR TITLE
add support for DROP_FUNCTION identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This way you have sure is a valid query before trying to identify the types.
 * DROP_TABLE
 * DROP_DATABASE
 * DROP_TRIGGER
+* DROP_FUNCTION
 * UNKNOWN (only available if strict mode is disabled)
 
 ## Execution types

--- a/src/parser.js
+++ b/src/parser.js
@@ -19,6 +19,7 @@ const EXECUTION_TYPES = {
   DROP_DATABASE: 'MODIFICATION',
   DROP_TABLE: 'MODIFICATION',
   DROP_TRIGGER: 'MODIFICATION',
+  DROP_FUNCTION: 'MODIFICATION',
   TRUNCATE: 'MODIFICATION',
   UNKNOWN: 'UNKNOWN',
 };
@@ -291,6 +292,7 @@ function createDropStatementParser ({ isStrict }) {
           { type: 'keyword', value: 'TABLE' },
           { type: 'keyword', value: 'DATABASE' },
           { type: 'keyword', value: 'TRIGGER' },
+          { type: 'keyword', value: 'FUNCTION' },
         ],
       },
       add: (token) => {

--- a/test/identifier/single-statement.spec.js
+++ b/test/identifier/single-statement.spec.js
@@ -353,6 +353,21 @@ describe('identifier', function () {
       expect(actual).to.eql(expected);
     });
 
+    it('should identify "DROP FUNCTION" statement', function () {
+      const sql = 'DROP FUNCTION sqrt(integer);';
+      const actual = identify(sql);
+      const expected = [
+        {
+          start: 0,
+          end: 27,
+          text: sql,
+          type: 'DROP_FUNCTION',
+          executionType: 'MODIFICATION',
+        },
+      ];
+      expect(actual).to.eql(expected);
+    });
+
     it('should identify "TRUNCATE TABLE" statement', function () {
       const actual = identify('TRUNCATE TABLE Persons;');
       const expected = [


### PR DESCRIPTION
Closes #19

All supported database types have the same syntax for drop function statements.