### PR TITLE
bump version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sql-query-identifier",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "A SQL query identifier",
   "license": "MIT",
   "main": "lib/index.js",


### PR DESCRIPTION
This will be the next release, I've got nothing new waiting in the wings and will not have time to do #25 for a while yet, so might as well release, keep moving forward.

Changelog:
```
## Breaking Changes

* The module sets minimum supported version of Node to 10. While this package may run on Node 6 and 8, it is unsupported. Older versions of Node will not work.

## Build

* Convert module to TypeScript (does not affect downstream usage)
```