### PR TITLE
Add support for identifying statements using CTE

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -139,6 +139,9 @@ export function parse (input: string, isStrict = true, dialect: Dialect = 'gener
       statementParser = createStatementParserByToken(token, { isStrict, dialect });
       if (cteState.isCte) {
         statementParser.getStatement().start = cteState.state.start;
+        cteState.isCte = false;
+        cteState.asSeen = false;
+        cteState.statementEnd = false;
       }
     }
 

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -18,6 +18,7 @@ const KEYWORDS = [
   'FUNCTION',
   'DATABASE',
   'TRUNCATE',
+  'WITH',
 ];
 
 const INDIVIDUALS: Record<string, string> = {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -19,6 +19,7 @@ const KEYWORDS = [
   'DATABASE',
   'TRUNCATE',
   'WITH',
+  'AS',
 ];
 
 const INDIVIDUALS: Record<string, string> = {

--- a/test/identifier/multiple-statement.spec.ts
+++ b/test/identifier/multiple-statement.spec.ts
@@ -53,7 +53,7 @@ describe('identifier', function () {
       expect(actual).to.eql(expected);
     });
 
-    it('should able to detect a statement even without know its type when strict is disabled', function () {
+    it('should able to detect queries with a CTE in middle query', function () {
       const actual = identify(`
         INSERT INTO Persons (PersonID, Name) VALUES (1, 'Jack');
 
@@ -76,8 +76,8 @@ describe('identifier', function () {
           start: 75,
           end: 227,
           text: 'WITH employee AS (SELECT * FROM Employees)\n        SELECT * FROM employee WHERE ID < 20\n        UNION ALL\n        SELECT * FROM employee WHERE Sex = \'M\';',
-          type: 'UNKNOWN',
-          executionType: 'UNKNOWN',
+          type: 'SELECT',
+          executionType: 'LISTING',
         },
         {
           start: 238,

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -566,21 +566,18 @@ describe('identifier', function () {
       expect(actual).to.eql(expected);
     });
 
-    it('should able to detect a statement even without know its type when strict is disabled - WITH', function () {
-      const actual = identify(`
-        WITH employee AS (SELECT * FROM Employees)
-        SELECT * FROM employee WHERE ID < 20
-        UNION ALL
-        SELECT * FROM employee WHERE Sex = 'M'
-      `, { strict: false });
+    it('should identify statement using CTE - WITH', () => {
+      const sql = `WITH cte_name (column1, column2) AS (
+        SELECT * FROM table
+      )
+      SELECT * FROM cte_name;`;
+
+      const actual = identify(sql);
       const expected = [
         {
-          start: 9,
-          end: 167,
-          text: 'WITH employee AS (SELECT * FROM Employees)\n        SELECT * FROM employee WHERE ID < 20\n        UNION ALL\n        SELECT * FROM employee WHERE Sex = \'M\'\n      ',
-          type: 'UNKNOWN',
-          executionType: 'UNKNOWN',
-        },
+          start: 0,
+          end: 28
+        }
       ];
 
       expect(actual).to.eql(expected);

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -566,7 +566,7 @@ describe('identifier', function () {
       expect(actual).to.eql(expected);
     });
 
-    it('should identify statement using CTE - WITH', () => {
+    it('should identify statement using CTE with column list', () => {
       const sql = `WITH cte_name (column1, column2) AS (
         SELECT * FROM table
       )
@@ -576,11 +576,51 @@ describe('identifier', function () {
       const expected = [
         {
           start: 0,
-          end: 28
-        }
+          end: 102,
+          text: sql,
+          type: 'SELECT',
+          executionType: 'LISTING',
+        },
       ];
 
       expect(actual).to.eql(expected);
     });
+
+    it('should identify statement using multiple CTE and no column list', () => {
+      const sql = `WITH
+      cte1 AS
+      (
+        SELECT 1 AS id
+      ),
+      cte2 AS
+      (
+        SELECT 2 AS id
+      ),
+      cte3 AS
+      (
+        SELECT 3 as id
+      )
+      SELECT  *
+      FROM    cte1
+      UNION ALL
+      SELECT  *
+      FROM    cte2
+      UNION ALL
+      SELECT  *
+      FROM    cte3`;
+
+      const actual = identify(sql);
+      const expected = [
+        {
+          start: 0,
+          end: 301,
+          text: sql,
+          type: 'SELECT',
+          executionType: 'LISTING',
+        },
+      ];
+
+      expect(actual).to.eql(expected);
+    })
   });
 });


### PR DESCRIPTION
Closes #25

This adds support for "Common Table Expressions" as part of queries, where it follows the grammar

```
[ WITH <common_table_expression> [ ,...n ] ]  
  
<common_table_expression>::=  
    expression_name [ ( column_name [ ,...n ] ) ]  
    AS  
    ( CTE_query_definition )  
```

While ANSI SQL specifies that CTE can only be used with SELECT queries, some dialects allow it before the range of SELECT, UPDATE, INSERT, DELETE and so I figured there's probably no harm in just having it generic default to that.