### PR TITLE
Add support for alter statements

### DIFF
--- a/src/defines.ts
+++ b/src/defines.ts
@@ -17,6 +17,12 @@ export type StatementType = 'INSERT'
   | 'DROP_TRIGGER'
   | 'DROP_FUNCTION'
   | 'DROP_INDEX'
+  | 'ALTER_DATABASE'
+  | 'ALTER_TABLE'
+  | 'ALTER_VIEW'
+  | 'ALTER_TRIGGER'
+  | 'ALTER_FUNCTION'
+  | 'ALTER_INDEX'
   | 'UNKNOWN';
 export type ExecutionType = 'LISTING' | 'MODIFICATION' | 'UNKNOWN';
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -430,12 +430,16 @@ function createAlterStatementParser (options: ParseOptions) {
       validation: {
         requireBefore: ['whitespace'],
         acceptTokens: [
-          { type: 'keyword', value: 'DATABASE' },
-          { type: 'keyword', value: 'SCHEMA' },
+          ...(options.dialect !== 'sqlite'
+            ? [
+              { type: 'keyword', value: 'DATABASE' },
+              { type: 'keyword', value: 'TRIGGER' },
+              { type: 'keyword', value: 'FUNCTION' },
+              { type: 'keyword', value: 'INDEX' },
+            ]
+            : []),
           { type: 'keyword', value: 'TABLE' },
           { type: 'keyword', value: 'VIEW' },
-          { type: 'keyword', value: 'TRIGGER' },
-          { type: 'keyword', value: 'FUNCTION' },
         ],
       },
       add: (token) => {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -19,6 +19,7 @@ const KEYWORDS = [
   'TRIGGER',
   'FUNCTION',
   'INDEX',
+  'ALTER',
   'TRUNCATE',
   'WITH',
   'AS',

--- a/test/tokenizer/index.spec.ts
+++ b/test/tokenizer/index.spec.ts
@@ -187,6 +187,17 @@ describe('scan', function () {
     expect(actual).to.eql(expected);
   });
 
+  it('scans ALTER keyword', () => {
+    const actual = scanToken(initState('ALTER'));
+    const expected = {
+      type: 'keyword',
+      value: 'ALTER',
+      start: 0,
+      end: 4,
+    };
+    expect(actual).to.eql(expected);
+  });
+
   it('scans \'Hello World\' as string value', function () {
     const actual = scanToken(initState('\'Hello World\''));
     const expected = {


### PR DESCRIPTION
Adds support for identifying the `ALTER <foo>` queries across databases. Relatively simple as no DB has anything that can come between the two keywords. The only thing here is that a handful of the alter types are disabled for sqlite as it lacks support for them (have to do a `DROP` then `CREATE` to get similar functionality).