### PR TITLE
Fix handling semicolon in middle of CTE statement

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -128,7 +128,7 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
         continue;
         // If we're scanning in a CTE, handle someone putting a semicolon anywhere (after 'with',
         // after semicolon, etc.) along it to "early terminate".
-      } else if (cteState.isCte && cteState.parens === 0 && token.type === 'semicolon') {
+      } else if (cteState.isCte && token.type === 'semicolon') {
         topLevelStatement.tokens.push(token);
         prevState = tokenState;
         topLevelStatement.body.push({
@@ -141,6 +141,7 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
         cteState.isCte = false;
         cteState.asSeen = false;
         cteState.statementEnd = false;
+        cteState.parens = 0;
         continue;
       } else if (cteState.isCte && !cteState.statementEnd) {
         if (cteState.asSeen) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -111,8 +111,8 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
     const token = scanToken(tokenState, dialect);
 
     if (!statementParser) {
-      // ignore blank tokens that are not in a statement
-      if (ignoreOutsideBlankTokens.includes(token.type)) {
+      // ignore blank tokens before the start of a CTE / not part of a statement
+      if (!cteState.isCte && ignoreOutsideBlankTokens.includes(token.type)) {
         topLevelStatement.tokens.push(token);
         prevState = tokenState;
         continue;
@@ -125,6 +125,22 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
         topLevelStatement.tokens.push(token);
         cteState.state = tokenState;
         prevState = tokenState;
+        continue;
+        // If we're scanning in a CTE, handle someone putting a semicolon anywhere (after 'with',
+        // after semicolon, etc.) along it to "early terminate".
+      } else if (cteState.isCte && cteState.parens === 0 && token.type === 'semicolon') {
+        topLevelStatement.tokens.push(token);
+        prevState = tokenState;
+        topLevelStatement.body.push({
+          start: cteState.state.start,
+          end: token.end,
+          type: 'UNKNOWN',
+          executionType: 'UNKNOWN',
+          parameters: [],
+        });
+        cteState.isCte = false;
+        cteState.asSeen = false;
+        cteState.statementEnd = false;
         continue;
       } else if (cteState.isCte && !cteState.statementEnd) {
         if (cteState.asSeen) {
@@ -147,6 +163,15 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
         cteState.asSeen = false;
         cteState.statementEnd = false;
 
+        topLevelStatement.tokens.push(token);
+        prevState = tokenState;
+        continue;
+        // Ignore blank tokens after the end of the CTE till start of statement
+      } else if (
+        cteState.isCte &&
+        cteState.statementEnd &&
+        ignoreOutsideBlankTokens.includes(token.type)
+      ) {
         topLevelStatement.tokens.push(token);
         prevState = tokenState;
         continue;

--- a/test/identifier/multiple-statement.spec.ts
+++ b/test/identifier/multiple-statement.spec.ts
@@ -89,50 +89,6 @@ describe('identifier', () => {
       expect(actual).to.eql(expected);
     });
 
-    it('should able to detect queries with a CTE in middle query', () => {
-      const actual = identify(
-        `
-        INSERT INTO Persons (PersonID, Name) VALUES (1, 'Jack');
-
-        WITH employee AS (SELECT * FROM Employees)
-        SELECT * FROM employee WHERE ID < 20
-        UNION ALL
-        SELECT * FROM employee WHERE Sex = 'M';
-
-        SELECT * FROM Persons;
-      `,
-        { strict: false },
-      );
-      const expected = [
-        {
-          start: 9,
-          end: 64,
-          text: "INSERT INTO Persons (PersonID, Name) VALUES (1, 'Jack');",
-          type: 'INSERT',
-          executionType: 'MODIFICATION',
-          parameters: [],
-        },
-        {
-          start: 75,
-          end: 227,
-          text: "WITH employee AS (SELECT * FROM Employees)\n        SELECT * FROM employee WHERE ID < 20\n        UNION ALL\n        SELECT * FROM employee WHERE Sex = 'M';",
-          type: 'SELECT',
-          executionType: 'LISTING',
-          parameters: [],
-        },
-        {
-          start: 238,
-          end: 259,
-          text: 'SELECT * FROM Persons;',
-          type: 'SELECT',
-          executionType: 'LISTING',
-          parameters: [],
-        },
-      ];
-
-      expect(actual).to.eql(expected);
-    });
-
     it('should able to ignore empty statements (extra semicolons)', () => {
       const actual = identify(
         `
@@ -169,6 +125,114 @@ describe('identifier', () => {
       ];
 
       expect(actual).to.eql(expected);
+    });
+
+    describe('identifying multiple statements with CTEs', () => {
+      it('should able to detect queries with a CTE in middle query', () => {
+        const actual = identify(
+          `
+          INSERT INTO Persons (PersonID, Name) VALUES (1, 'Jack');
+
+          WITH employee AS (SELECT * FROM Employees)
+          SELECT * FROM employee WHERE ID < 20
+          UNION ALL
+          SELECT * FROM employee WHERE Sex = 'M';
+
+          SELECT * FROM Persons;
+        `,
+          { strict: false },
+        );
+        const expected = [
+          {
+            start: 11,
+            end: 66,
+            text: "INSERT INTO Persons (PersonID, Name) VALUES (1, 'Jack');",
+            type: 'INSERT',
+            executionType: 'MODIFICATION',
+            parameters: [],
+          },
+          {
+            start: 79,
+            end: 237,
+            text: "WITH employee AS (SELECT * FROM Employees)\n          SELECT * FROM employee WHERE ID < 20\n          UNION ALL\n          SELECT * FROM employee WHERE Sex = 'M';",
+            type: 'SELECT',
+            executionType: 'LISTING',
+            parameters: [],
+          },
+          {
+            start: 250,
+            end: 271,
+            text: 'SELECT * FROM Persons;',
+            type: 'SELECT',
+            executionType: 'LISTING',
+            parameters: [],
+          },
+        ];
+
+        expect(actual).to.eql(expected);
+      });
+
+      it('should identify statements with semicolon following CTE', () => {
+        const statement1 = `with temp as (
+          select * from foo
+        );`;
+        const statement2 = `select * from foo;`;
+        const sql = `${statement1}\n${statement2}`;
+        const actual = identify(sql);
+
+        const expected = [
+          {
+            start: 0,
+            end: 52,
+            text: statement1,
+            type: 'UNKNOWN',
+            executionType: 'UNKNOWN',
+            parameters: [],
+          },
+          {
+            start: 54,
+            end: 71,
+            text: statement2,
+            type: 'SELECT',
+            executionType: 'LISTING',
+            parameters: [],
+          },
+        ];
+
+        expect(actual).to.eql(expected);
+        expect(sql.substring(actual[0].start, actual[0].end + 1)).to.eql(statement1);
+        expect(sql.substring(actual[1].start, actual[1].end + 1)).to.eql(statement2);
+      });
+    });
+
+    it('should identify statements with semicolon following with keyword', () => {
+      const statement1 = `with;`;
+      const statement2 = `select * from foo;`;
+      const sql = `${statement1}\n${statement2}`;
+      const actual = identify(sql);
+
+      const expected = [
+        {
+          start: 0,
+          end: 4,
+          text: statement1,
+          type: 'UNKNOWN',
+          executionType: 'UNKNOWN',
+          parameters: [],
+        },
+        {
+          start: 6,
+          end: 23,
+          text: statement2,
+          type: 'SELECT',
+          executionType: 'LISTING',
+          parameters: [],
+        },
+      ];
+
+      expect(actual).to.eql(expected);
+      expect(sql.substring(actual[0].start, actual[0].end + 1)).to.eql(statement1);
+      expect(sql.substring(actual[1].start, actual[1].end + 1)).to.eql(statement2);
     });
   });
 });

--- a/test/identifier/multiple-statement.spec.ts
+++ b/test/identifier/multiple-statement.spec.ts
@@ -234,5 +234,35 @@ describe('identifier', () => {
       expect(sql.substring(actual[0].start, actual[0].end + 1)).to.eql(statement1);
       expect(sql.substring(actual[1].start, actual[1].end + 1)).to.eql(statement2);
     });
+
+    it('should identify statements with semicolon inside CTE parens', () => {
+      const statement1 = `with temp as ( SELECT ;`;
+      const statement2 = 'select * from foo';
+      const sql = `${statement1}\n${statement2}`;
+      const actual = identify(sql);
+
+      const expected = [
+        {
+          start: 0,
+          end: 22,
+          text: statement1,
+          type: 'UNKNOWN',
+          executionType: 'UNKNOWN',
+          parameters: [],
+        },
+        {
+          start: 24,
+          end: 40,
+          text: statement2,
+          type: 'SELECT',
+          executionType: 'LISTING',
+          parameters: [],
+        },
+      ];
+
+      expect(actual).to.eql(expected);
+      expect(sql.substring(actual[0].start, actual[0].end + 1)).to.eql(statement1);
+      expect(sql.substring(actual[1].start, actual[1].end + 1)).to.eql(statement2);
+    });
   });
 });


### PR DESCRIPTION
PR fixes a bug where parser would not properly split queries that  had a semicolon in the middle of the CTE / before the actual start of a statement. An example would be the following:

```sql
with temp as (
    select * from foo
);
select * from foo;
```

where the parser would ignore the semicolon terminating the first statement, and just return it as one statement. Now, if the parser detects a semi-colon at the top-level while parsing the CTE, it will act as a terminating symbol for that statement and start a new statement following it.