### PR TITLE
Identify all invalid statements as unknown when not strict

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -255,7 +255,7 @@ function createStatementParserByToken(token: Token, options: ParseOptions): Stat
     }
   }
 
-  if (!options.isStrict && token.type === 'unknown') {
+  if (!options.isStrict) {
     return createUnknownStatementParser(options);
   }
 

--- a/test/parser/single-statements.spec.ts
+++ b/test/parser/single-statements.spec.ts
@@ -9,6 +9,51 @@ describe('parser', () => {
     it('should throw an error including the unknown statement', () => {
       expect(() => parse('LIST * FROM Persons')).to.throw('Invalid statement parser "LIST"');
     });
+
+    describe('with strict disabled', () => {
+      it('should parse if first token is unknown', () => {
+        const actual = parse('LIST * FROM foo', false);
+        actual.tokens = aggregateUnknownTokens(actual.tokens);
+        expect(actual).to.eql({
+          type: 'QUERY',
+          start: 0,
+          end: 14,
+          body: [
+            {
+              start: 0,
+              end: 14,
+              parameters: [],
+              type: 'UNKNOWN',
+              executionType: 'UNKNOWN',
+            },
+          ],
+          tokens: [{ type: 'unknown', value: 'LIST * FROM foo', start: 0, end: 14 }],
+        });
+      });
+
+      it('should parse if first token is invalid keyword', () => {
+        const actual = parse('AS bar LEFT JOIN foo', false);
+        actual.tokens = aggregateUnknownTokens(actual.tokens);
+        expect(actual).to.eql({
+          type: 'QUERY',
+          start: 0,
+          end: 19,
+          body: [
+            {
+              start: 0,
+              end: 19,
+              parameters: [],
+              type: 'UNKNOWN',
+              executionType: 'UNKNOWN',
+            },
+          ],
+          tokens: [
+            { type: 'keyword', value: 'AS', start: 0, end: 1 },
+            { type: 'unknown', value: ' bar LEFT JOIN foo', start: 2, end: 19 },
+          ],
+        });
+      });
+    });
   });
 
   describe('given queries with a single statement', () => {


### PR DESCRIPTION
This PR expands what gets marked as unknown statements when using non-strict mode. Previously, only statements that started with an unknown token would be allowed to be marked as unknown, however we're seeing in practice many people wish to split off random pieces of queries into "separate statements" while they test a query, and sometimes those statements start with keywords and strings and other types of tokens.