### PR TITLE
Oracle Dialect - explicitly supporting compound statements

### DIFF
--- a/src/defines.ts
+++ b/src/defines.ts
@@ -48,6 +48,7 @@ export interface IdentifyResult {
 
 export interface Statement {
   start: number;
+  startToken?: Token;
   end: number;
   type?: StatementType;
   executionType?: ExecutionType;

--- a/src/defines.ts
+++ b/src/defines.ts
@@ -1,4 +1,4 @@
-export const DIALECTS = ['mssql', 'sqlite', 'mysql', 'psql', 'generic'] as const;
+export const DIALECTS = ['mssql', 'sqlite', 'mysql', 'oracle', 'psql', 'generic'] as const;
 export type Dialect = typeof DIALECTS[number];
 export type StatementType =
   | 'INSERT'
@@ -27,6 +27,7 @@ export type StatementType =
   | 'ALTER_TRIGGER'
   | 'ALTER_FUNCTION'
   | 'ALTER_INDEX'
+  | 'ANON_BLOCK'
   | 'UNKNOWN';
 
 export type ExecutionType = 'LISTING' | 'MODIFICATION' | 'UNKNOWN';

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -56,12 +56,17 @@ export const EXECUTION_TYPES: Record<StatementType, ExecutionType> = {
 
 const genericStatementsWithEnds = ['CREATE_TRIGGER', 'CREATE_FUNCTION'];
 
-const dialectStatementsWithEnds: any = {
+const dialectStatementsWithEnds = {
   oracle: ['ANON_BLOCK'],
+  generic: [],
+  psql: [],
+  mysql: [],
+  mssql: [],
+  sqlite: [],
 };
 
-function statementsWithEnds(dialect: Dialect) {
-  const dialectS = dialectStatementsWithEnds[dialect] || [];
+function statementsWithEnds(dialect: Dialect): string[] {
+  const dialectS: string[] = dialectStatementsWithEnds[dialect] || [];
   return [...genericStatementsWithEnds, ...dialectS];
 }
 
@@ -637,6 +642,7 @@ function stateMachineStatementParser(
       // statements in this library.
       if (
         dialect === 'oracle' &&
+        statement.type &&
         statementsWithEnds(dialect).includes(statement.type) &&
         token.value.toUpperCase() === 'END' &&
         openBlocks == 0

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -74,7 +74,6 @@ const blockOpeners: Record<Dialect, string[]> = {
   oracle: ['BEGIN', 'CASE', 'IF', 'DECLARE'],
 };
 
-
 interface ParseOptions {
   isStrict: boolean;
   dialect: Dialect;
@@ -290,7 +289,6 @@ function createSelectStatementParser(options: ParseOptions) {
         acceptTokens: [{ type: 'keyword', value: 'SELECT' }],
       },
       add: (token) => {
-
         statement.type = 'SELECT';
         if (statement.start < 0) {
           statement.start = token.start;
@@ -305,7 +303,7 @@ function createSelectStatementParser(options: ParseOptions) {
 
 function createBlockStatementParser(options: ParseOptions) {
   const statement = createInitialStatement();
-  statement.type = 'ANON_BLOCK'
+  statement.type = 'ANON_BLOCK';
   // ...start will always be 0? I guess not if there's whitespace...
   // but probably fine for now.
   statement.start = 0;
@@ -313,7 +311,10 @@ function createBlockStatementParser(options: ParseOptions) {
     {
       preCanGoToNext: () => false,
       validation: {
-        acceptTokens: [{ type: 'keyword', value: 'BEGIN' }, { type: 'keyword', value: 'DECLARE'}],
+        acceptTokens: [
+          { type: 'keyword', value: 'BEGIN' },
+          { type: 'keyword', value: 'DECLARE' },
+        ],
       },
       add: (token) => {
         if (statement.start < 0) {
@@ -612,7 +613,7 @@ function stateMachineStatementParser(
     },
 
     addToken(token: Token) {
-      console.log('addToken (start)', token)
+      console.log('addToken (start)', token);
       /* eslint no-param-reassign: 0 */
       if (statement.endStatement) {
         throw new Error('This statement has already got to the end.');
@@ -637,10 +638,11 @@ function stateMachineStatementParser(
       if (
         dialect === 'oracle' &&
         statementsWithEnds(dialect).includes(statement.type) &&
-        token.value.toUpperCase() === 'END' && openBlocks == 0
+        token.value.toUpperCase() === 'END' &&
+        openBlocks == 0
       ) {
-        statement.endStatement = 'END'
-        return
+        statement.endStatement = 'END';
+        return;
       }
 
       // this should not count ANON_BLOCK statements as expression blocks
@@ -660,7 +662,7 @@ function stateMachineStatementParser(
         return;
       }
 
-      console.log('pre openblock check', token)
+      console.log('pre openblock check', token);
       if (
         token.type === 'keyword' &&
         blockOpeners[dialect].includes(token.value) &&
@@ -672,8 +674,8 @@ function stateMachineStatementParser(
           statement.startToken?.value.toUpperCase() !== 'DECLARE' &&
           token.value.toUpperCase() === 'BEGIN' &&
           beginSkipped === false
-          ) {
-          beginSkipped = true
+        ) {
+          beginSkipped = true;
           // skip
         } else {
           lastBlockOpener = token;
@@ -683,7 +685,7 @@ function stateMachineStatementParser(
         }
       }
 
-      console.log('post open block check')
+      console.log('post open block check');
 
       if (
         token.type === 'parameter' &&
@@ -837,10 +839,10 @@ function stateMachineStatementParser(
           `Expected any of these tokens ${expecteds} instead of type="${token.type}" value="${token.value}" (currentStep=${currentStepIndex}).`,
         );
       } else {
-        statement.startToken = token
+        statement.startToken = token;
       }
 
-      console.log("ADDING TOKEN", token)
+      console.log('ADDING TOKEN', token);
 
       currentStep.add(token);
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -57,12 +57,12 @@ export const EXECUTION_TYPES: Record<StatementType, ExecutionType> = {
 const genericStatementsWithEnds = ['CREATE_TRIGGER', 'CREATE_FUNCTION'];
 
 const dialectStatementsWithEnds: any = {
-  'oracle': ['DECLARE', 'BEGIN']
-}
+  oracle: ['DECLARE', 'BEGIN'],
+};
 
 function statementsWithEnds(dialect: Dialect) {
-  const dialectS = dialectStatementsWithEnds[dialect] || []
-  return [...genericStatementsWithEnds, ...dialectS]
+  const dialectS = dialectStatementsWithEnds[dialect] || [];
+  return [...genericStatementsWithEnds, ...dialectS];
 }
 
 const blockOpeners: Record<Dialect, string[]> = {
@@ -71,7 +71,7 @@ const blockOpeners: Record<Dialect, string[]> = {
   mysql: ['BEGIN', 'CASE', 'LOOP', 'IF'],
   mssql: ['BEGIN', 'CASE'],
   sqlite: ['BEGIN', 'CASE'],
-  oracle: ['BEGIN',]
+  oracle: ['BEGIN'],
 };
 
 interface ParseOptions {
@@ -265,7 +265,7 @@ function createStatementParserByToken(token: Token, options: ParseOptions): Stat
       // lovely oracle, yum yum
       case 'BEGIN':
       case 'DECLARE':
-        return createBlockStatementParser(options)
+        return createBlockStatementParser(options);
       default:
         break;
     }
@@ -289,7 +289,7 @@ function createSelectStatementParser(options: ParseOptions) {
         acceptTokens: [{ type: 'keyword', value: 'SELECT' }],
       },
       add: (token) => {
-        console.log("adding token", token)
+        console.log('adding token', token);
 
         statement.type = 'SELECT';
         if (statement.start < 0) {
@@ -304,25 +304,25 @@ function createSelectStatementParser(options: ParseOptions) {
 }
 
 function createBlockStatementParser(options: ParseOptions) {
-  console.log("creating block parser!")
+  console.log('creating block parser!');
   const statement = createInitialStatement();
   const steps: Step[] = [
     {
       preCanGoToNext: () => false,
       validation: {
-        acceptTokens: [{type: 'keyword', value: 'BEGIN'}],
+        acceptTokens: [{ type: 'keyword', value: 'BEGIN' }],
       },
       add: (token) => {
-        console.log("adding token", token)
+        console.log('adding token', token);
         statement.type = 'ANON_BLOCK';
         if (statement.start < 0) {
           statement.start = token.start;
         }
       },
-      postCanGoToNext: () => true
-    }
-  ]
-  return stateMachineStatementParser(statement, steps, options)
+      postCanGoToNext: () => true,
+    },
+  ];
+  return stateMachineStatementParser(statement, steps, options);
 }
 
 function createInsertStatementParser(options: ParseOptions) {
@@ -614,11 +614,12 @@ function stateMachineStatementParser(
         throw new Error('This statement has already got to the end.');
       }
 
-      console.log("TOKEN/STATEMENT", token, statement)
+      console.log('TOKEN/STATEMENT', token, statement);
       if (
         statement.type &&
         token.type === 'semicolon' &&
-        (!statementsWithEnds(dialect).includes(statement.type) || (openBlocks === 0 && statement.canEnd))
+        (!statementsWithEnds(dialect).includes(statement.type) ||
+          (openBlocks === 0 && statement.canEnd))
       ) {
         statement.endStatement = ';';
         return;

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -28,15 +28,12 @@ const KEYWORDS = [
 ];
 
 const DIALECT_KEYWORDS: any = {
-  'oracle': [
-    'BEGIN', 'DECLARE', 'INTO'
-  ]
-}
+  oracle: ['BEGIN', 'DECLARE', 'INTO'],
+};
 
 function dialectKeywords(d: Dialect) {
-  return DIALECT_KEYWORDS[d] || []
+  return DIALECT_KEYWORDS[d] || [];
 }
-
 
 const INDIVIDUALS: Record<string, Token['type']> = {
   ';': 'semicolon',
@@ -117,7 +114,7 @@ function peek(state: State): Char {
 }
 
 function isKeyword(word: string, dialect: Dialect): boolean {
-  const keywords = [...KEYWORDS, ...dialectKeywords(dialect)]
+  const keywords = [...KEYWORDS, ...dialectKeywords(dialect)];
   return keywords.includes(word.toUpperCase());
 }
 

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -27,12 +27,17 @@ const KEYWORDS = [
   'MATERIALIZED',
 ];
 
-const DIALECT_KEYWORDS: any = {
+const DIALECT_KEYWORDS = {
   oracle: ['BEGIN', 'DECLARE', 'INTO'],
+  generic: [],
+  psql: [],
+  mysql: [],
+  mssql: [],
+  sqlite: [],
 };
 
-function dialectKeywords(d: Dialect) {
-  return DIALECT_KEYWORDS[d] || [];
+function dialectKeywords(dialect: Dialect): string[] {
+  return DIALECT_KEYWORDS[dialect] || [];
 }
 
 const INDIVIDUALS: Record<string, Token['type']> = {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -27,6 +27,17 @@ const KEYWORDS = [
   'MATERIALIZED',
 ];
 
+const DIALECT_KEYWORDS: any = {
+  'oracle': [
+    'BEGIN', 'DECLARE', 'INTO'
+  ]
+}
+
+function dialectKeywords(d: Dialect) {
+  return DIALECT_KEYWORDS[d] || []
+}
+
+
 const INDIVIDUALS: Record<string, Token['type']> = {
   ';': 'semicolon',
 };
@@ -70,7 +81,7 @@ export function scanToken(state: State, dialect: Dialect = 'generic'): Token {
   }
 
   if (isLetter(ch)) {
-    return scanWord(state);
+    return scanWord(state, dialect);
   }
 
   const individual = scanIndividualCharacter(state);
@@ -105,8 +116,9 @@ function peek(state: State): Char {
   return state.input[state.position + 1];
 }
 
-function isKeyword(word: string): boolean {
-  return KEYWORDS.includes(word.toUpperCase());
+function isKeyword(word: string, dialect: Dialect): boolean {
+  const keywords = [...KEYWORDS, ...dialectKeywords(dialect)]
+  return keywords.includes(word.toUpperCase());
 }
 
 function resolveIndividualTokenType(ch: string): Token['type'] | undefined {
@@ -310,7 +322,7 @@ function scanQuotedIdentifier(state: State, endToken: Char): Token {
   };
 }
 
-function scanWord(state: State): Token {
+function scanWord(state: State, dialect: Dialect): Token {
   let nextChar: Char;
 
   do {
@@ -322,7 +334,7 @@ function scanWord(state: State): Token {
   }
 
   const value = state.input.slice(state.start, state.position + 1);
-  if (!isKeyword(value)) {
+  if (!isKeyword(value, dialect)) {
     return skipWord(state, value);
   }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 describe('identify', () => {
   it('should throw error for invalid dialect', () => {
     expect(() => identify('SELECT * FROM foo', { dialect: 'invalid' as Dialect })).to.throw(
-      'Unknown dialect. Allowed values: mssql, sqlite, mysql, psql, generic',
+      'Unknown dialect. Allowed values: mssql, sqlite, mysql, oracle, psql, generic',
     );
   });
 

--- a/test/parser/multiple-statements.spec.ts
+++ b/test/parser/multiple-statements.spec.ts
@@ -19,6 +19,12 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
+            "startToken": {
+              "end": 5,
+              "start": 0,
+              "type": "keyword",
+              "value": "INSERT",
+            },
             end: 55,
             type: 'INSERT',
             executionType: 'MODIFICATION',
@@ -27,6 +33,12 @@ describe('parser', () => {
           },
           {
             start: 56,
+            "startToken": {
+              "end": 61,
+              "start": 56,
+              "type": "keyword",
+              "value": "SELECT",
+            },
             end: 76,
             type: 'SELECT',
             executionType: 'LISTING',
@@ -88,6 +100,12 @@ describe('parser', () => {
           // nodes
           {
             start: 9,
+            startToken: {
+              start: 9,
+              end:14,
+              value: "INSERT",
+              type: "keyword"
+            },
             end: 64,
             type: 'INSERT',
             executionType: 'MODIFICATION',
@@ -96,6 +114,12 @@ describe('parser', () => {
           },
           {
             start: 74,
+            startToken: {
+              value: "SELECT",
+              type: "keyword",
+              start: 74,
+              end: 79
+            },
             end: 103,
             type: 'SELECT',
             executionType: 'LISTING',

--- a/test/parser/multiple-statements.spec.ts
+++ b/test/parser/multiple-statements.spec.ts
@@ -19,11 +19,11 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
-            "startToken": {
-              "end": 5,
-              "start": 0,
-              "type": "keyword",
-              "value": "INSERT",
+            startToken: {
+              end: 5,
+              start: 0,
+              type: 'keyword',
+              value: 'INSERT',
             },
             end: 55,
             type: 'INSERT',
@@ -33,11 +33,11 @@ describe('parser', () => {
           },
           {
             start: 56,
-            "startToken": {
-              "end": 61,
-              "start": 56,
-              "type": "keyword",
-              "value": "SELECT",
+            startToken: {
+              end: 61,
+              start: 56,
+              type: 'keyword',
+              value: 'SELECT',
             },
             end: 76,
             type: 'SELECT',
@@ -102,9 +102,9 @@ describe('parser', () => {
             start: 9,
             startToken: {
               start: 9,
-              end:14,
-              value: "INSERT",
-              type: "keyword"
+              end: 14,
+              value: 'INSERT',
+              type: 'keyword',
             },
             end: 64,
             type: 'INSERT',
@@ -115,10 +115,10 @@ describe('parser', () => {
           {
             start: 74,
             startToken: {
-              value: "SELECT",
-              type: "keyword",
+              value: 'SELECT',
+              type: 'keyword',
               start: 74,
-              end: 79
+              end: 79,
             },
             end: 103,
             type: 'SELECT',

--- a/test/parser/oracle.spec.ts
+++ b/test/parser/oracle.spec.ts
@@ -2,14 +2,13 @@ import { parse } from '../../src/parser';
 import { expect } from 'chai';
 
 describe('Parser for oracle', () => {
-
   describe('Given a CASE Statement', () => {
     it('should parse a simple case statement', () => {
-      const sql = `SELECT CASE WHEN a = 'a' THEN 'foo' ELSE 'bar' END CASE from table;`
-      const result = parse(sql, false, 'oracle')
-      expect(result.body.length).to.eql(1)
-    })
-  })
+      const sql = `SELECT CASE WHEN a = 'a' THEN 'foo' ELSE 'bar' END CASE from table;`;
+      const result = parse(sql, false, 'oracle');
+      expect(result.body.length).to.eql(1);
+    });
+  });
 
   describe('given an anonymous block with an OUT pram', () => {
     it('should treat a simple block as a single query', () => {
@@ -25,7 +24,6 @@ describe('Parser for oracle', () => {
       expect(result.body[0].start).to.eq(0);
       expect(result.body[0].end).to.eq(119);
       expect(result.body.length).to.eql(1);
-
     });
 
     it('should identify a block query and a normal query together', () => {
@@ -37,14 +35,13 @@ describe('Parser for oracle', () => {
       END;
 
       select * from another_thing
-      `
-      const result = parse(sql, false, 'oracle')
-      expect(result.body.length).to.eql(2)
-      expect(result.body[0].start).to.eq(0)
-      expect(result.body[0].end).to.eq(98)
-      expect(result.body[1].start).to.eq(107)
-    })
-
+      `;
+      const result = parse(sql, false, 'oracle');
+      expect(result.body.length).to.eql(2);
+      expect(result.body[0].start).to.eq(0);
+      expect(result.body[0].end).to.eq(98);
+      expect(result.body[1].start).to.eq(107);
+    });
   });
   describe('given an anonymous block with a variable', () => {
     it('should treat a block with DECLARE and another query as two separate queries', () => {
@@ -60,7 +57,7 @@ describe('Parser for oracle', () => {
         select * from foo;
       `;
       const result = parse(sql, false, 'oracle');
-      console.log(result)
+      console.log(result);
       expect(result.body.length).to.eql(2);
       expect(result.body[0].start).to.eq(0);
       expect(result.body[0].end).to.eq(166);
@@ -131,11 +128,11 @@ describe('Parser for oracle', () => {
               WHEN no_data_found THEN
                 DBMS_OUTPUT.PUT_LINE('Employee ' || n_emp_id || ' not found');
           END;
-        END;`
+        END;`;
       // yes this is still just one statement.
       const result = parse(sql, false, 'oracle');
-      console.log(result)
+      console.log(result);
       expect(result.body.length).to.eql(1);
-    })
+    });
   });
 });

--- a/test/parser/oracle.spec.ts
+++ b/test/parser/oracle.spec.ts
@@ -1,0 +1,85 @@
+import { parse } from '../../src/parser';
+import { expect } from 'chai';
+
+describe('Parser for oracle', () => {
+  describe('given an anonymous block with an OUT pram', () => {
+    it.only("should treat a simple block as a single query", () => {
+      const sql = `BEGIN
+          SELECT
+            cols.column_name INTO :variable
+          FROM
+            example_table;
+        END`
+      const result = parse(sql, false, 'oracle')
+
+      console.log(result)
+
+      expect(result.body.length).to.eql(1)
+    })
+
+  })
+  describe('given an anonymous block with a variable', () => {
+    it("should treat a simple block as a single query", () => {
+      const sql =   `
+        DECLARE
+          PK_NAME VARCHAR(200);
+        BEGIN
+          SELECT
+            cols.column_name INTO PK_NAME
+          FROM
+            example_table;
+        END;
+      `
+      const result = parse(sql, false, 'oracle')
+
+      expect(result.body.length).to.eql(1)
+    })
+
+    it("Should treat a block with two queries as a single query", () => {
+      const sql = `
+        DECLARE
+          PK_NAME VARCHAR(200);
+          FOO integer;
+
+        BEGIN
+          SELECT
+            cols.column_name INTO PK_NAME
+          FROM
+            example_table;
+          SELECT 1 INTO FOO from other_example;
+        END;
+      `
+      const result = parse(sql, false, 'oracle')
+      expect(result.body.length).to.eql(1)
+    })
+
+    it("Should treat a complex block as a single query", () => {
+      const sql = `
+        DECLARE
+          PK_NAME VARCHAR(200);
+
+        BEGIN
+          EXECUTE IMMEDIATE ('CREATE SEQUENCE "untitled_table3_seq"');
+
+        SELECT
+          cols.column_name INTO PK_NAME
+        FROM
+          all_constraints cons,
+          all_cons_columns cols
+        WHERE
+          cons.constraint_type = 'P'
+          AND cons.constraint_name = cols.constraint_name
+          AND cons.owner = cols.owner
+          AND cols.table_name = 'untitled_table3';
+
+        execute immediate (
+          'create or replace trigger "untitled_table3_autoinc_trg"  BEFORE INSERT on "untitled_table3"  for each row  declare  checking number := 1;  begin    if (:new."' || PK_NAME || '" is null) then      while checking >= 1 loop        select "untitled_table3_seq".nextval into :new."' || PK_NAME || '" from dual;        select count("' || PK_NAME || '") into checking from "untitled_table3"        where "' || PK_NAME || '" = :new."' || PK_NAME || '";      end loop;    end if;  end;'
+        );
+        END;
+      `
+      const result = parse(sql, false, 'oracle')
+      expect(result.body.length).to.eql(1)
+    })
+
+  })
+})

--- a/test/parser/oracle.spec.ts
+++ b/test/parser/oracle.spec.ts
@@ -3,24 +3,23 @@ import { expect } from 'chai';
 
 describe('Parser for oracle', () => {
   describe('given an anonymous block with an OUT pram', () => {
-    it.only("should treat a simple block as a single query", () => {
+    it.only('should treat a simple block as a single query', () => {
       const sql = `BEGIN
           SELECT
             cols.column_name INTO :variable
           FROM
             example_table;
-        END`
-      const result = parse(sql, false, 'oracle')
+        END`;
+      const result = parse(sql, false, 'oracle');
 
-      console.log(result)
+      console.log(result);
 
-      expect(result.body.length).to.eql(1)
-    })
-
-  })
+      expect(result.body.length).to.eql(1);
+    });
+  });
   describe('given an anonymous block with a variable', () => {
-    it("should treat a simple block as a single query", () => {
-      const sql =   `
+    it('should treat a simple block as a single query', () => {
+      const sql = `
         DECLARE
           PK_NAME VARCHAR(200);
         BEGIN
@@ -29,13 +28,13 @@ describe('Parser for oracle', () => {
           FROM
             example_table;
         END;
-      `
-      const result = parse(sql, false, 'oracle')
+      `;
+      const result = parse(sql, false, 'oracle');
 
-      expect(result.body.length).to.eql(1)
-    })
+      expect(result.body.length).to.eql(1);
+    });
 
-    it("Should treat a block with two queries as a single query", () => {
+    it('Should treat a block with two queries as a single query', () => {
       const sql = `
         DECLARE
           PK_NAME VARCHAR(200);
@@ -48,12 +47,12 @@ describe('Parser for oracle', () => {
             example_table;
           SELECT 1 INTO FOO from other_example;
         END;
-      `
-      const result = parse(sql, false, 'oracle')
-      expect(result.body.length).to.eql(1)
-    })
+      `;
+      const result = parse(sql, false, 'oracle');
+      expect(result.body.length).to.eql(1);
+    });
 
-    it("Should treat a complex block as a single query", () => {
+    it('Should treat a complex block as a single query', () => {
       const sql = `
         DECLARE
           PK_NAME VARCHAR(200);
@@ -76,10 +75,9 @@ describe('Parser for oracle', () => {
           'create or replace trigger "untitled_table3_autoinc_trg"  BEFORE INSERT on "untitled_table3"  for each row  declare  checking number := 1;  begin    if (:new."' || PK_NAME || '" is null) then      while checking >= 1 loop        select "untitled_table3_seq".nextval into :new."' || PK_NAME || '" from dual;        select count("' || PK_NAME || '") into checking from "untitled_table3"        where "' || PK_NAME || '" = :new."' || PK_NAME || '";      end loop;    end if;  end;'
         );
         END;
-      `
-      const result = parse(sql, false, 'oracle')
-      expect(result.body.length).to.eql(1)
-    })
-
-  })
-})
+      `;
+      const result = parse(sql, false, 'oracle');
+      expect(result.body.length).to.eql(1);
+    });
+  });
+});

--- a/test/parser/single-statements.spec.ts
+++ b/test/parser/single-statements.spec.ts
@@ -21,11 +21,11 @@ describe('parser', () => {
           body: [
             {
               start: 0,
-              "startToken": {
-                "end": 3,
-                "start": 0,
-                "type": "unknown",
-                "value": "LIST",
+              startToken: {
+                end: 3,
+                start: 0,
+                type: 'unknown',
+                value: 'LIST',
               },
               end: 14,
               parameters: [],
@@ -47,11 +47,11 @@ describe('parser', () => {
           body: [
             {
               start: 0,
-              "startToken": {
-                "end": 1,
-                "start": 0,
-                "type": "keyword",
-                "value": "AS",
+              startToken: {
+                end: 1,
+                start: 0,
+                type: 'keyword',
+                value: 'AS',
               },
               end: 19,
               parameters: [],
@@ -82,11 +82,11 @@ describe('parser', () => {
           {
             start: 0,
             end: 20,
-            "startToken": {
-                          "end": 5,
-              "start": 0,
-              "type": "keyword",
-              "value": "SELECT",
+            startToken: {
+              end: 5,
+              start: 0,
+              type: 'keyword',
+              value: 'SELECT',
             },
             type: 'SELECT',
             executionType: 'LISTING',
@@ -124,11 +124,11 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
-            "startToken": {
-              "end": 5,
-              "start": 0,
-              "type": "keyword",
-              "value": "select",
+            startToken: {
+              end: 5,
+              start: 0,
+              type: 'keyword',
+              value: 'select',
             },
             end: 20,
             type: 'SELECT',
@@ -167,11 +167,11 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
-            "startToken": {
-              "end": 11,
-              "start": 7,
-              "type": "keyword",
-              "value": "TABLE"
+            startToken: {
+              end: 11,
+              start: 7,
+              type: 'keyword',
+              value: 'TABLE',
             },
             end: 54,
             type: 'CREATE_TABLE',
@@ -230,11 +230,11 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
-            "startToken": {
-              "end": 14,
-              "start": 7,
-              "type": "keyword",
-              "value": "DATABASE",
+            startToken: {
+              end: 14,
+              start: 7,
+              type: 'keyword',
+              value: 'DATABASE',
             },
             end: 23,
             type: 'CREATE_DATABASE',
@@ -292,11 +292,11 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
-            "startToken": {
-              "end": 9,
-  "start": 5,
-  "type": "keyword",
-  "value": "TABLE",
+            startToken: {
+              end: 9,
+              start: 5,
+              type: 'keyword',
+              value: 'TABLE',
             },
             end: 18,
             type: 'DROP_TABLE',
@@ -354,11 +354,11 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
-            "startToken": {
-              "end": 12,
-  "start": 5,
-  "type": "keyword",
-  "value": "DATABASE",
+            startToken: {
+              end: 12,
+              start: 5,
+              type: 'keyword',
+              value: 'DATABASE',
             },
             end: 21,
             type: 'DROP_DATABASE',
@@ -415,11 +415,11 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
-            "startToken": {
-              "end": 5,
-  "start": 0,
-  "type": "keyword",
-  "value": "INSERT",
+            startToken: {
+              end: 5,
+              start: 0,
+              type: 'keyword',
+              value: 'INSERT',
             },
             end: 55,
             type: 'INSERT',
@@ -465,11 +465,11 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
-            "startToken": {
-              "end": 5,
-  "start": 0,
-  "type": "keyword",
-  "value": "UPDATE",
+            startToken: {
+              end: 5,
+              start: 0,
+              type: 'keyword',
+              value: 'UPDATE',
             },
             end: 51,
             type: 'UPDATE',
@@ -515,11 +515,11 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
-            "startToken": {
-              "end": 5,
-  "start": 0,
-  "type": "keyword",
-  "value": "DELETE",
+            startToken: {
+              end: 5,
+              start: 0,
+              type: 'keyword',
+              value: 'DELETE',
             },
             end: 38,
             type: 'DELETE',
@@ -565,11 +565,11 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
-            "startToken": {
-              "end": 7,
-  "start": 0,
-  "type": "keyword",
-  "value": "TRUNCATE",
+            startToken: {
+              end: 7,
+              start: 0,
+              type: 'keyword',
+              value: 'TRUNCATE',
             },
             end: 22,
             type: 'TRUNCATE',

--- a/test/parser/single-statements.spec.ts
+++ b/test/parser/single-statements.spec.ts
@@ -21,6 +21,12 @@ describe('parser', () => {
           body: [
             {
               start: 0,
+              "startToken": {
+                "end": 3,
+                "start": 0,
+                "type": "unknown",
+                "value": "LIST",
+              },
               end: 14,
               parameters: [],
               type: 'UNKNOWN',
@@ -41,6 +47,12 @@ describe('parser', () => {
           body: [
             {
               start: 0,
+              "startToken": {
+                "end": 1,
+                "start": 0,
+                "type": "keyword",
+                "value": "AS",
+              },
               end: 19,
               parameters: [],
               type: 'UNKNOWN',
@@ -70,6 +82,12 @@ describe('parser', () => {
           {
             start: 0,
             end: 20,
+            "startToken": {
+                          "end": 5,
+              "start": 0,
+              "type": "keyword",
+              "value": "SELECT",
+            },
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
@@ -106,6 +124,12 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
+            "startToken": {
+              "end": 5,
+              "start": 0,
+              "type": "keyword",
+              "value": "select",
+            },
             end: 20,
             type: 'SELECT',
             executionType: 'LISTING',
@@ -143,6 +167,12 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
+            "startToken": {
+              "end": 11,
+              "start": 7,
+              "type": "keyword",
+              "value": "TABLE"
+            },
             end: 54,
             type: 'CREATE_TABLE',
             executionType: 'MODIFICATION',
@@ -194,11 +224,18 @@ describe('parser', () => {
       const expected = {
         type: 'QUERY',
         start: 0,
+
         end: 23,
         body: [
           // nodes
           {
             start: 0,
+            "startToken": {
+              "end": 14,
+              "start": 7,
+              "type": "keyword",
+              "value": "DATABASE",
+            },
             end: 23,
             type: 'CREATE_DATABASE',
             executionType: 'MODIFICATION',
@@ -255,6 +292,12 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
+            "startToken": {
+              "end": 9,
+  "start": 5,
+  "type": "keyword",
+  "value": "TABLE",
+            },
             end: 18,
             type: 'DROP_TABLE',
             executionType: 'MODIFICATION',
@@ -311,6 +354,12 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
+            "startToken": {
+              "end": 12,
+  "start": 5,
+  "type": "keyword",
+  "value": "DATABASE",
+            },
             end: 21,
             type: 'DROP_DATABASE',
             executionType: 'MODIFICATION',
@@ -366,6 +415,12 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
+            "startToken": {
+              "end": 5,
+  "start": 0,
+  "type": "keyword",
+  "value": "INSERT",
+            },
             end: 55,
             type: 'INSERT',
             executionType: 'MODIFICATION',
@@ -410,6 +465,12 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
+            "startToken": {
+              "end": 5,
+  "start": 0,
+  "type": "keyword",
+  "value": "UPDATE",
+            },
             end: 51,
             type: 'UPDATE',
             executionType: 'MODIFICATION',
@@ -454,6 +515,12 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
+            "startToken": {
+              "end": 5,
+  "start": 0,
+  "type": "keyword",
+  "value": "DELETE",
+            },
             end: 38,
             type: 'DELETE',
             executionType: 'MODIFICATION',
@@ -498,6 +565,12 @@ describe('parser', () => {
           // nodes
           {
             start: 0,
+            "startToken": {
+              "end": 7,
+  "start": 0,
+  "type": "keyword",
+  "value": "TRUNCATE",
+            },
             end: 22,
             type: 'TRUNCATE',
             executionType: 'MODIFICATION',

--- a/test/tokenizer/oracle.spec.ts
+++ b/test/tokenizer/oracle.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { scanToken } from '../../src/tokenizer';
-import type { Dialect } from '../../src/defines';
 
 describe('oracle scanning', () => {
   const initState = (input: string) => ({

--- a/test/tokenizer/oracle.spec.ts
+++ b/test/tokenizer/oracle.spec.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { scanToken } from '../../src/tokenizer';
+import type { Dialect } from '../../src/defines';
+
+describe('oracle scanning', () => {
+  const initState = (input: string) => ({
+    input,
+    start: 0,
+    end: input.length - 1,
+    position: -1,
+  });
+
+  it('scans DECLARE keyword', () => {
+    const actual = scanToken(initState('DECLARE'), 'oracle');
+    const expected = {
+      type: 'keyword',
+      value: 'DECLARE',
+      start: 0,
+      end: 6,
+    };
+    expect(actual).to.eql(expected);
+  });
+
+
+})

--- a/test/tokenizer/oracle.spec.ts
+++ b/test/tokenizer/oracle.spec.ts
@@ -20,6 +20,4 @@ describe('oracle scanning', () => {
     };
     expect(actual).to.eql(expected);
   });
-
-
-})
+});


### PR DESCRIPTION
Oracle supports compound statements that look like this:

```sql
        DECLARE
          PK_NAME VARCHAR(200);
          FOO integer;

        BEGIN
          SELECT
            cols.column_name INTO PK_NAME
          FROM
            example_table;
          SELECT 1 INTO FOO from other_example;
        END;
```

It's like the begin/end blocks for functions and procedures....but around a whole set of queries. Oh and this requires that you select `INTO` a variable. Super weird.