### PR TITLE
Fix identifying psql parameters followed by comma

### DIFF
--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -233,9 +233,9 @@ function scanParameter(state: State, dialect: Dialect): Token {
 
     do {
       nextChar = read(state);
-    } while (!isNaN(Number(nextChar)) && !isWhitespace(nextChar) && nextChar !== null);
+    } while (nextChar !== null && !isNaN(Number(nextChar)) && !isWhitespace(nextChar));
 
-    if (isWhitespace(nextChar)) unread(state);
+    if (nextChar !== null) unread(state);
 
     const value = state.input.slice(state.start, state.position + 1);
 

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -1139,6 +1139,26 @@ describe('identifier', () => {
 
       expect(actual).to.eql(expected);
     });
+
+    it('Should extract positional Parameters with trailing commas', () => {
+      const actual = identify('SELECT $1,$2 FROM foo', {
+        dialect: 'psql',
+        strict: true,
+      });
+      const expected = [
+        {
+          start: 0,
+          end: 20,
+          text: 'SELECT $1,$2 FROM foo',
+          type: 'SELECT',
+          executionType: 'LISTING',
+          parameters: ['$1', '$2'],
+        },
+      ];
+
+      expect(actual).to.eql(expected);
+    });
+
     it('Should extract named Parameters', () => {
       const actual = identify('SELECT * FROM Persons where x = :one and y = :two and a = :one', {
         dialect: 'mssql',
@@ -1157,6 +1177,7 @@ describe('identifier', () => {
 
       expect(actual).to.eql(expected);
     });
+
     it('Should extract question mark Parameters', () => {
       const actual = identify('SELECT * FROM Persons where x = ? and y = ? and a = ?', {
         dialect: 'mysql',

--- a/test/tokenizer/index.spec.ts
+++ b/test/tokenizer/index.spec.ts
@@ -342,6 +342,17 @@ describe('scan', () => {
         };
         expect(actual).to.eql(expected);
       });
+
+      it('should not include trailing non-numbers for psql', () => {
+        const actual = scanToken(initState('$1,'), 'psql');
+        const expected = {
+          type: 'parameter',
+          value: '$1',
+          start: 0,
+          end: 1,
+        };
+        expect(actual).to.eql(expected);
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #54 

PR fixes a bug where if a psql parameter was followed by a non-number character (e.g. a comma), it would include the character in the parameter value. The issue was that we were only rewinding our state when we broke out of value identifier for a whitespace character, when it should be any character, which is covered by checking for `nextChar !== null`.

Included a test both within the tokenizer where the bug was, as well at the identify level just for sanity checking.