### PR TITLE
Fix identifying DECLARE statements for bigquery

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -65,7 +65,7 @@ const blockOpeners: Record<Dialect, string[]> = {
   mssql: ['BEGIN', 'CASE'],
   sqlite: ['BEGIN', 'CASE'],
   oracle: ['DECLARE', 'BEGIN', 'CASE'],
-  bigquery: ['DECLARE', 'BEGIN', 'CASE'],
+  bigquery: ['BEGIN', 'CASE'],
 };
 
 interface ParseOptions {

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -1361,5 +1361,24 @@ describe('identifier', () => {
 
       expect(actual).to.eql(expected);
     });
+
+    it('Should identify declare statement as unknown for bigquery', () => {
+      const actual = identify("DECLARE start_time TIMESTAMP DEFAULT '2022-08-08 13:05:00';", {
+        dialect: 'bigquery',
+        strict: false,
+      });
+      const expected = [
+        {
+          start: 0,
+          end: 58,
+          text: "DECLARE start_time TIMESTAMP DEFAULT '2022-08-08 13:05:00';",
+          type: 'UNKNOWN',
+          executionType: 'UNKNOWN',
+          parameters: [],
+        },
+      ];
+
+      expect(actual).to.eql(expected);
+    });
   });
 });


### PR DESCRIPTION
This PR fixes a bug where doing `DECLARE start_time TIMESTAMP DEFAULT '2022';` would get parsed incorrectly for bigquery, due to specifying `DECLARE` as a block opener, though it's not. While bigquery allows `DECLARE` statements anywhere, and they live for the lifetime of the DB session, unlike oracle where the `DECLARE` is attached to the following `BEGIN` block.