### PR TITLE
Fix parsing bigquery control structures

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -273,12 +273,16 @@ function createStatementParserByToken(token: Token, options: ParseOptions): Stat
         return createDeleteStatementParser(options);
       case 'TRUNCATE':
         return createTruncateStatementParser(options);
-      case 'DECLARE':
       case 'BEGIN':
+        if (['bigquery', 'oracle'].includes(options.dialect)) {
+          return createBlockStatementParser(options);
+        }
+        break;
+      case 'DECLARE':
         if (options.dialect === 'oracle') {
           return createBlockStatementParser(options);
         }
-      // eslint-disable-next-line no-fallthrough
+        break;
       default:
         break;
     }
@@ -324,7 +328,7 @@ function createBlockStatementParser(options: ParseOptions) {
       preCanGoToNext: () => false,
       validation: {
         acceptTokens: [
-          { type: 'keyword', value: 'DECLARE' },
+          ...(options.dialect === 'oracle' ? [{ type: 'keyword', value: 'DECLARE' }] : []),
           { type: 'keyword', value: 'BEGIN' },
         ],
       },

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -201,7 +201,7 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
         continue;
       }
 
-      statementParser = createStatementParserByToken(token, { isStrict, dialect });
+      statementParser = createStatementParserByToken(token, nextToken, { isStrict, dialect });
       if (cteState.isCte) {
         statementParser.getStatement().start = cteState.state.start;
         cteState.isCte = false;
@@ -254,7 +254,11 @@ function initState({ input, prevState }: { input?: string; prevState?: State }):
   };
 }
 
-function createStatementParserByToken(token: Token, options: ParseOptions): StatementParser {
+function createStatementParserByToken(
+  token: Token,
+  nextToken: Token,
+  options: ParseOptions,
+): StatementParser {
   if (token.type === 'keyword') {
     switch (token.value.toUpperCase()) {
       case 'SELECT':
@@ -274,7 +278,7 @@ function createStatementParserByToken(token: Token, options: ParseOptions): Stat
       case 'TRUNCATE':
         return createTruncateStatementParser(options);
       case 'BEGIN':
-        if (['bigquery', 'oracle'].includes(options.dialect)) {
+        if (['bigquery', 'oracle'].includes(options.dialect) && nextToken.value !== 'TRANSACTION') {
           return createBlockStatementParser(options);
         }
         break;

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -28,6 +28,11 @@ const KEYWORDS = [
   'BEGIN',
   'DECLARE',
   'CASE',
+  'LOOP',
+  'IF',
+  'REPEAT',
+  'WHILE',
+  'FOR',
   'PROCEDURE',
 ];
 

--- a/test/parser/bigquery.spec.ts
+++ b/test/parser/bigquery.spec.ts
@@ -61,4 +61,11 @@ describe('Parser for bigquery', () => {
       });
     });
   });
+
+  it('parses BEGIN statement as ANON_BLOCK', () => {
+    const result = parse(`BEGIN SELECT 1; END; SELECT 1;`, false, 'bigquery');
+    expect(result.body.length).to.eql(2);
+    expect(result.body[0].type).to.eql('ANON_BLOCK');
+    expect(result.body[1].type).to.eql('SELECT');
+  });
 });

--- a/test/parser/bigquery.spec.ts
+++ b/test/parser/bigquery.spec.ts
@@ -1,0 +1,62 @@
+import { parse } from '../../src/parser';
+import { expect } from 'chai';
+
+describe('Parser for bigquery', () => {
+  // all testcases are taken straight from bigquery docs on procedural language
+  // see https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language
+  describe('control structures', () => {
+    [
+      `CASE
+        WHEN
+          EXISTS(SELECT 1 FROM schema.products_a WHERE product_id = target_product_id)
+          THEN SELECT 'found product in products_a table';
+        WHEN
+          EXISTS(SELECT 1 FROM schema.products_b WHERE product_id = target_product_id)
+          THEN SELECT 'found product in products_b table';
+        ELSE
+          SELECT 'did not find product';
+      END CASE;`,
+      `IF EXISTS(SELECT 1 FROM schema.products
+        WHERE product_id = target_product_id) THEN
+        SELECT CONCAT('found product ', CAST(target_product_id AS STRING));
+        ELSEIF EXISTS(SELECT 1 FROM schema.more_products
+                WHERE product_id = target_product_id) THEN
+        SELECT CONCAT('found product from more_products table',
+        CAST(target_product_id AS STRING));
+        ELSE
+        SELECT CONCAT('did not find product ', CAST(target_product_id AS STRING));
+      END IF;`,
+      `LOOP
+        SET x = x + 1;
+        IF x >= 10 THEN
+          LEAVE;
+        END IF;
+      END LOOP;`,
+      `REPEAT
+        SET x = x + 1;
+        SELECT x;
+        UNTIL x >= 3
+      END REPEAT;`,
+      `WHILE x < 0 DO
+          SET x = x + 1;
+          SELECT x;
+      END WHILE;`,
+      `FOR record IN
+        (SELECT word, word_count
+        FROM bigquery-public-data.samples.shakespeare
+        LIMIT 5)
+      DO
+        SELECT record.word, record.word_count;
+      END FOR;`,
+    ].forEach((sql) => {
+      it(`parses ${sql.substring(
+        0,
+        Math.min(sql.indexOf(' '), sql.indexOf('\n')),
+      )} structure`, () => {
+        const result = parse(sql, false, 'bigquery');
+        expect(result.body.length).to.eql(1);
+        expect(sql.substring(result.body[0].start, result.body[0].end + 1)).to.eql(sql);
+      });
+    });
+  });
+});

--- a/test/parser/bigquery.spec.ts
+++ b/test/parser/bigquery.spec.ts
@@ -53,9 +53,11 @@ describe('Parser for bigquery', () => {
         0,
         Math.min(sql.indexOf(' '), sql.indexOf('\n')),
       )} structure`, () => {
-        const result = parse(sql, false, 'bigquery');
-        expect(result.body.length).to.eql(1);
+        const result = parse(`${sql}\nSELECT 1;`, false, 'bigquery');
+        expect(result.body.length).to.eql(2);
         expect(sql.substring(result.body[0].start, result.body[0].end + 1)).to.eql(sql);
+        expect(result.body[0].type).to.eql('UNKNOWN');
+        expect(result.body[1].type).to.eql('SELECT');
       });
     });
   });

--- a/test/parser/bigquery.spec.ts
+++ b/test/parser/bigquery.spec.ts
@@ -68,4 +68,12 @@ describe('Parser for bigquery', () => {
     expect(result.body[0].type).to.eql('ANON_BLOCK');
     expect(result.body[1].type).to.eql('SELECT');
   });
+
+  it('parses BEGIN TRANSACTION as UNKNOWN', () => {
+    const result = parse(`BEGIN TRANSACTION; SELECT 1; COMMIT;`, false, 'bigquery');
+    expect(result.body.length).to.eql(3);
+    expect(result.body[0].type).to.eql('UNKNOWN');
+    expect(result.body[1].type).to.eql('SELECT');
+    expect(result.body[2].type).to.eql('UNKNOWN');
+  });
 });


### PR DESCRIPTION
PR improves parsing BigQuery control structures so that they're fully detected as their own potential standalone statements. Unlike Oracle, BigQuery's procedural language can be used without first using `DECLARE` or `SET` or `BEGIN` and can be completely standalone, and so we need to be able to detect that these are separate statements, and not part of a larger `ANON_BLOCK` like Oracle. `BEGIN` though for BigQuery can start an anon_block if it's the first word, and not followed by `"TRANSACTION"` which gives similar behavior as Oracle for that.

See `CASE` or `FOR` in the below examples as statements that are completely standalone. The other loop structures probably expect a `DECLARE` or `SET` before it, but there's no guarantee.