### PR TITLE
Fix identifying queries with lowercase block openers

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -673,7 +673,7 @@ function stateMachineStatementParser(
 
       if (
         token.type === 'keyword' &&
-        blockOpeners[dialect].includes(token.value) &&
+        blockOpeners[dialect].includes(token.value.toUpperCase()) &&
         prevNonWhitespaceToken?.value.toUpperCase() !== 'END' &&
         (token.value.toUpperCase() !== 'BEGIN' ||
           (token.value.toUpperCase() === 'BEGIN' &&

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -1398,7 +1398,7 @@ describe('identifier', () => {
           text: sql,
           type: 'CREATE_PROCEDURE',
           executionType: 'MODIFICATION',
-                    parameters: [],
+          parameters: [],
         },
       ];
 

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -1380,5 +1380,29 @@ describe('identifier', () => {
 
       expect(actual).to.eql(expected);
     });
+
+    it('Should parse lower case block opener in query correctly', () => {
+      const sql = `CREATE OR REPLACE PROCEDURE foo.bar (col string)
+        BEGIN
+        if foo is not null then
+            SET foo = 'bar';
+        end if;
+
+        SELECT 1;
+        END;`;
+      const actual = identify(sql, { dialect: 'bigquery', strict: false });
+      const expected = [
+        {
+          start: 0,
+          end: 170,
+          text: sql,
+          type: 'CREATE_PROCEDURE',
+          executionType: 'MODIFICATION',
+          parameters: [],
+        },
+      ];
+
+      expect(actual).to.eql(expected);
+    });
   });
 });


### PR DESCRIPTION
PR fixes parsing queries that have a lowercase block opener as part of the query. Before, it would not detect the block opener (as it expects an upper case string for comparison), but we would properly detect the `end` for that block, and so would close out any currently in progress blocks, and then the next encountered semi-colon would close out the statement. For the test case, this would mean that we'd end up with three statements, with the `SELECT 1` as its own statement, followed by the `;` (where the `END` gets parsed into oblivion, see #62).