### PR TITLE
Fix parsing single END statement

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -657,7 +657,7 @@ function stateMachineStatementParser(
         return;
       }
 
-      if (token.value.toUpperCase() === 'END') {
+      if (openBlocks > 0 && token.value.toUpperCase() === 'END') {
         openBlocks--;
         if (openBlocks === 0) {
           statement.canEnd = true;

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -1380,5 +1380,22 @@ describe('identifier', () => {
 
       expect(actual).to.eql(expected);
     });
+
+    it('Should identify a lone END', () => {
+      const sql = 'END;';
+      const actual = identify(sql, { strict: false });
+      const expected = [
+        {
+          start: 0,
+          end: 3,
+          text: sql,
+          type: 'UNKNOWN',
+          executionType: 'UNKNOWN',
+          parameters: [],
+        },
+      ];
+
+      expect(actual).to.eql(expected);
+    });
   });
 });


### PR DESCRIPTION
Fixes #62 

PR fixes a bug where `END;` on its own was not getting parsed properly such that the returned text would be just `;`. I feel like the fix being just don't treat `END` as a block closer if there's not been a block opener is probably fine, couldn't really come up with a broken query that might violate that, but people do surprising things in the name of breaking queries.